### PR TITLE
Delete build in type `account_name`

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -83,7 +83,6 @@ namespace eosio { namespace chain {
       built_in_types.emplace("block_timestamp_type",      pack_unpack<block_timestamp_type>());
 
       built_in_types.emplace("name",                      pack_unpack<name>());
-      built_in_types.emplace("account_name",              pack_unpack<name>());
 
       built_in_types.emplace("bytes",                     pack_unpack<bytes>());
       built_in_types.emplace("string",                    pack_unpack<string>());

--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -356,7 +356,7 @@ namespace eosio { namespace chain {
 
       const auto linked_permission_name = lookup_minimum_permission(link.account, link.code, link.type);
 
-      if( !linked_permission_name ) // if action is linked to {root}.any permission
+      if( !linked_permission_name ) // if action is linked to eosio.any permission
          return;
 
       EOS_ASSERT( get_permission(auth).satisfies( get_permission({link.account, *linked_permission_name}),
@@ -491,7 +491,7 @@ namespace eosio { namespace chain {
 
             if( !special_case ) {
                auto min_permission_name = lookup_minimum_permission(declared_auth.actor, act.account, act.name);
-               if( min_permission_name ) { // since special cases were already handled, it should only be false if the permission is {root}.any
+               if( min_permission_name ) { // since special cases were already handled, it should only be false if the permission is eosio.any
                   const auto& min_permission = get_permission({declared_auth.actor, *min_permission_name});
                   EOS_ASSERT( get_permission(declared_auth).satisfies( min_permission,
                                                                        _db.get_index<permission_index>().indices() ),

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -315,7 +315,6 @@ struct controller_impl {
     wasmif( cfg.wasm_runtime, cfg.eosvmoc_tierup, db, cfg.state_dir, cfg.eosvmoc_config ),
     resource_limits( db ),
     authorization( s, db ),
-    txfee(),
     protocol_features( std::move(pfs) ),
     conf( cfg ),
     chain_id( chain_id ),

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -6,7 +6,6 @@
 #include <eosio/chain/apply_context.hpp>
 #include <eosio/chain/transaction.hpp>
 #include <eosio/chain/exceptions.hpp>
-#include <eosio/chain/memory_db.hpp>
 
 #include <eosio/chain/account_object.hpp>
 #include <eosio/chain/code_object.hpp>
@@ -18,11 +17,11 @@
 #include <eosio/chain/wasm_interface.hpp>
 #include <eosio/chain/abi_serializer.hpp>
 
-#include <eosio/chain/config_on_chain.hpp>
-
 #include <eosio/chain/authorization_manager.hpp>
 #include <eosio/chain/resource_limits.hpp>
-// #include <eosio/chain/contract_table_objects.hpp>
+
+#include <eosio/chain/memory_db.hpp>
+#include <eosio/chain/config_on_chain.hpp>
 #include <eosio/chain/config.hpp>
 #include <eosio/chain/txfee_manager.hpp>
 
@@ -46,7 +45,7 @@ void validate_authority_precondition( const apply_context& context, const author
       if( a.permission.permission == config::owner_name || a.permission.permission == config::active_name )
          continue; // account was already checked to exist, so its owner and active permissions should exist
 
-      if( a.permission.permission == config::eosio_code_name ) // virtual {root}.code permission does not really exist but is allowed
+      if( a.permission.permission == config::eosio_code_name ) // virtual eosio.code permission does not really exist but is allowed
          continue;
 
       try {

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -4,7 +4,6 @@
 #include <eosio/chain/exceptions.hpp>
 #include <fc/variant_object.hpp>
 #include <fc/scoped_exit.hpp>
-#include <fc/reflect/reflect.hpp>
 
 namespace eosio { namespace chain {
 

--- a/libraries/chain/include/eosio/chain/global_property_object.hpp
+++ b/libraries/chain/include/eosio/chain/global_property_object.hpp
@@ -139,10 +139,6 @@ CHAINBASE_SET_INDEX_TYPE(eosio::chain::dynamic_global_property_object,
                          eosio::chain::dynamic_global_property_multi_index)
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::force_property_object, eosio::chain::force_property_multi_index)
 
-FC_REFLECT(eosio::chain::dynamic_global_property_object,
-            (global_action_sequence)
-          )
-
 FC_REFLECT(eosio::chain::global_property_object,
             (proposed_schedule_block_num)(proposed_schedule)(configuration)(chain_id)
           )
@@ -159,3 +155,6 @@ FC_REFLECT(eosio::chain::snapshot_global_property_object,
             (proposed_schedule_block_num)(proposed_schedule)(configuration)(chain_id)
           )
 
+FC_REFLECT(eosio::chain::dynamic_global_property_object,
+            (global_action_sequence)
+          )

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -592,7 +592,7 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
 
    try {
       try {
-         genesis_state gs; // Check if ROOT_KEY is bad
+         genesis_state gs; // Check if EOSIO_ROOT_KEY is bad
       } catch ( const fc::exception& ) {
          elog( "ROOT_KEY ('${root_key}') is invalid. Recompile with a valid public key.",
                ("root_key", genesis_state::system_account_root_key));

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -159,7 +159,6 @@ public:
 
       vector<permission>         permissions;
 
-      // useless, but keep same with eosio
       fc::variant                total_resources;
       fc::variant                self_delegated_bandwidth;
       fc::variant                refund_request;

--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -183,7 +183,7 @@ struct txn_test_gen_plugin_impl {
             trxs.emplace_back(std::move(trx));
          }
 
-         //set newaccountT contract to token & initialize it
+         //set newaccountT contract to eosio.token & initialize it
          {
             signed_transaction trx;
 

--- a/tutorials/genesis/force.msig.abi
+++ b/tutorials/genesis/force.msig.abi
@@ -4,6 +4,9 @@
       "new_type_name": "permission_name",
       "type": "name"
    },{
+      "new_type_name": "account_name",
+      "type": "name"
+   },{
       "new_type_name": "action_name",
       "type": "name"
   }],

--- a/tutorials/genesis/force.token.abi
+++ b/tutorials/genesis/force.token.abi
@@ -1,6 +1,9 @@
 {
   "version": "eosio::abi/1.0",
-  "types": [],
+  "types": [{
+      "new_type_name": "account_name",
+      "type": "name"
+   }],
   "structs": [
     {
       "name": "transfer",


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

In Eosforce, account_name is as a build-in type, it diff between eosio and useless, so deleted in codex.io.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
